### PR TITLE
merge webpack configs to support more advanced testing setups

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -6,6 +6,7 @@ var commondir = require('commondir');
 var Promise = require('bluebird');
 var MemoryFS = require('memory-fs');
 var debug = require('debug')('zuul-builder-webpack');
+var merge = require('lodash.merge');
 
 var webpack = require('webpack');
 
@@ -34,19 +35,15 @@ module.exports = function(files, config) {
   }
   entry = entry.concat(files);
 
-  var compiler = webpack({
+  var compiler = webpack(merge(config, {
     context: commondir(files),
     entry: entry,
     devtool: 'source-map',
     output: {
       path: '/',
       filename: 'bundle.js'
-    },
-    resolve: config.resolve,
-    resolveLoader: config.resolveLoader,
-    module: config.module,
-    plugins: config.plugins
-  });
+    }
+  }));
   compiler.outputFileSystem = new MemoryFS();
 
 	compiler.plugin('compile', function(err) {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "bluebird": "^2.9.24",
     "commondir": "^1.0.1",
     "debug": "^2.1.3",
+    "lodash.merge": "^3.3.2",
     "memory-fs": "^0.2.0"
   }
 }


### PR DESCRIPTION
This merges the webpack configs which allows the use of more features during the webpack build processes. For example, setting the `node` config item required to make some modules work correctly.
