### PR TITLE
feat: add support for specifying the webpack config url

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Create the following ``zuul.config.js``:
       builder: 'zuul-builder-webpack',
       webpack: {
         // webpack config goes here
-        // you can also just do require('./webpack.config')
+        // you can also just do require('./webpack.config') or './webpack.config'
         // to reference your webpack configuration
       }
     };

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var path = require('path');
+
 var EventEmitter = require('events').EventEmitter;
 
 var commondir = require('commondir');
@@ -26,7 +28,12 @@ function makeDeferred() {
 module.exports = function(files, config) {
   var deferred = makeDeferred();
 
-  config = config.webpack || {};
+  if (config.webpack) {
+    // If the value passed in is a string, we're going to assume it's a file location, otherwise assume its the config.
+    config = typeof config.webpack === 'string' ? require(path.resolve(config.webpack)) : webpack.config;
+  } else {
+    config = {};
+  }
 
   var entry = [];
   if (config.zuul && config.zuul.entry) {


### PR DESCRIPTION
This also adds support for using `.zuul.yml` in conjunction with `webpack.config.js`! :tada:
### Example `.zuul.yml` config

``` yml
# ...
builder: zuul-builder-webpack
webpack: ./webpack.test.config
```
### Example `zuul.config.js`

``` js
module.exports = {
  // ...
  builder: 'zuul-builder-webpack',
  webpack: './webpack.test.config.js'
};
```

this closes #10 
